### PR TITLE
Fix Test Filenames

### DIFF
--- a/Fig.Tests/JsonProviderTests.cs
+++ b/Fig.Tests/JsonProviderTests.cs
@@ -1,31 +1,24 @@
-﻿using System;
-using System.Collections.Specialized;
-using Fig.AppSettingsXml;
+﻿using System.IO;
+using Fig;
 using NUnit.Framework;
 
 namespace Tests
 {
-    public class XmlProviderTests
+    public class JsonProviderTests
     {
-        AppSettingsXml _xmlProvider;
+        AppSettingsJsonProvider _jsonProvider;
 
         [SetUp]
         public void Setup()
         {
-            var comparer = StringComparer.InvariantCultureIgnoreCase;
-            var nvc = new NameValueCollection(comparer);
-            nvc.Add("Timeout", "42");
-            nvc.Add("ConnectionStrings.DefaultConnection",
-                "DataSource=app.db");
-            nvc.Add("Servers.0", "10.0.0.1");
-            nvc.Add("Servers.1", "10.0.0.2");
-            _xmlProvider = new AppSettingsXml(nvc);
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
+            _jsonProvider = new AppSettingsJsonProvider(path);
         }
 
         [Test]
         public void CanReadPrimitive()
         {
-            var actual = _xmlProvider.Get("Timeout");
+            var actual = _jsonProvider.Get("Timeout");
             Assert.AreEqual("42", actual);
         }
 
@@ -33,16 +26,25 @@ namespace Tests
         [Test]
         public void CanReadNestedPrimitive()
         {
-            var actual = _xmlProvider.Get("ConnectionStrings.DefaultConnection");
+            var actual = _jsonProvider.Get("ConnectionStrings.DefaultConnection");
             Assert.AreEqual("DataSource=app.db", actual);
         }
 
         [Test]
         public void CanReadArray()
         {
-            var actual = _xmlProvider.Get("Servers.0");
+            var actual = _jsonProvider.Get("Servers.0");
             Assert.AreEqual("10.0.0.1", actual);
-            Assert.AreEqual("10.0.0.2", _xmlProvider.Get("Servers.1"));
+            Assert.AreEqual("10.0.0.2", _jsonProvider.Get("Servers.1"));
         }
+
+        [Test]
+        public void CanReadArrayOfObjects()
+        {
+            var actual = _jsonProvider.Get("Simpsons.0.Name");
+            Assert.AreEqual("Bart", actual);
+            Assert.AreEqual("Homer", _jsonProvider.Get("simpsons.1.name"));
+        }
+
     }
 }

--- a/Fig.Tests/JsonProviderTests.cs
+++ b/Fig.Tests/JsonProviderTests.cs
@@ -1,24 +1,31 @@
-﻿using System.IO;
-using Fig;
+﻿using System;
+using System.Collections.Specialized;
+using Fig.AppSettingsXml;
 using NUnit.Framework;
 
 namespace Tests
 {
-    public class JsonProviderTests
+    public class XmlProviderTests
     {
-        AppSettingsJsonProvider _jsonProvider;
+        AppSettingsXml _xmlProvider;
 
         [SetUp]
         public void Setup()
         {
-            var path = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
-            _jsonProvider = new AppSettingsJsonProvider(path);
+            var comparer = StringComparer.InvariantCultureIgnoreCase;
+            var nvc = new NameValueCollection(comparer);
+            nvc.Add("Timeout", "42");
+            nvc.Add("ConnectionStrings.DefaultConnection",
+                "DataSource=app.db");
+            nvc.Add("Servers.0", "10.0.0.1");
+            nvc.Add("Servers.1", "10.0.0.2");
+            _xmlProvider = new AppSettingsXml(nvc);
         }
 
         [Test]
         public void CanReadPrimitive()
         {
-            var actual = _jsonProvider.Get("Timeout");
+            var actual = _xmlProvider.Get("Timeout");
             Assert.AreEqual("42", actual);
         }
 
@@ -26,25 +33,16 @@ namespace Tests
         [Test]
         public void CanReadNestedPrimitive()
         {
-            var actual = _jsonProvider.Get("ConnectionStrings.DefaultConnection");
+            var actual = _xmlProvider.Get("ConnectionStrings.DefaultConnection");
             Assert.AreEqual("DataSource=app.db", actual);
         }
 
         [Test]
         public void CanReadArray()
         {
-            var actual = _jsonProvider.Get("Servers.0");
+            var actual = _xmlProvider.Get("Servers.0");
             Assert.AreEqual("10.0.0.1", actual);
-            Assert.AreEqual("10.0.0.2", _jsonProvider.Get("Servers.1"));
+            Assert.AreEqual("10.0.0.2", _xmlProvider.Get("Servers.1"));
         }
-
-        [Test]
-        public void CanReadArrayOfObjects()
-        {
-            var actual = _jsonProvider.Get("Simpsons.0.Name");
-            Assert.AreEqual("Bart", actual);
-            Assert.AreEqual("Homer", _jsonProvider.Get("simpsons.1.name"));
-        }
-
     }
 }

--- a/Fig.Tests/XmlProviderTests.cs
+++ b/Fig.Tests/XmlProviderTests.cs
@@ -1,31 +1,24 @@
-﻿using System;
-using System.Collections.Specialized;
-using Fig.AppSettingsXml;
+﻿using System.IO;
+using Fig;
 using NUnit.Framework;
 
 namespace Tests
 {
-    public class XmlProviderTests
+    public class JsonProviderTests
     {
-        AppSettingsXml _xmlProvider;
+        AppSettingsJsonProvider _jsonProvider;
 
         [SetUp]
         public void Setup()
         {
-            var comparer = StringComparer.InvariantCultureIgnoreCase;
-            var nvc = new NameValueCollection(comparer);
-            nvc.Add("Timeout", "42");
-            nvc.Add("ConnectionStrings.DefaultConnection",
-                "DataSource=app.db");
-            nvc.Add("Servers.0", "10.0.0.1");
-            nvc.Add("Servers.1", "10.0.0.2");
-            _xmlProvider = new AppSettingsXml(nvc);
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
+            _jsonProvider = new AppSettingsJsonProvider(path);
         }
 
         [Test]
         public void CanReadPrimitive()
         {
-            var actual = _xmlProvider.Get("Timeout");
+            var actual = _jsonProvider.Get("Timeout");
             Assert.AreEqual("42", actual);
         }
 
@@ -33,16 +26,25 @@ namespace Tests
         [Test]
         public void CanReadNestedPrimitive()
         {
-            var actual = _xmlProvider.Get("ConnectionStrings.DefaultConnection");
+            var actual = _jsonProvider.Get("ConnectionStrings.DefaultConnection");
             Assert.AreEqual("DataSource=app.db", actual);
         }
 
         [Test]
         public void CanReadArray()
         {
-            var actual = _xmlProvider.Get("Servers.0");
+            var actual = _jsonProvider.Get("Servers.0");
             Assert.AreEqual("10.0.0.1", actual);
-            Assert.AreEqual("10.0.0.2", _xmlProvider.Get("Servers.1"));
+            Assert.AreEqual("10.0.0.2", _jsonProvider.Get("Servers.1"));
         }
+
+        [Test]
+        public void CanReadArrayOfObjects()
+        {
+            var actual = _jsonProvider.Get("Simpsons.0.Name");
+            Assert.AreEqual("Bart", actual);
+            Assert.AreEqual("Homer", _jsonProvider.Get("simpsons.1.name"));
+        }
+
     }
 }

--- a/Fig.Tests/XmlProviderTests.cs
+++ b/Fig.Tests/XmlProviderTests.cs
@@ -1,24 +1,31 @@
-﻿using System.IO;
-using Fig;
+﻿using System;
+using System.Collections.Specialized;
+using Fig.AppSettingsXml;
 using NUnit.Framework;
 
 namespace Tests
 {
-    public class JsonProviderTests
+    public class XmlProviderTests
     {
-        AppSettingsJsonProvider _jsonProvider;
+        AppSettingsXml _xmlProvider;
 
         [SetUp]
         public void Setup()
         {
-            var path = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
-            _jsonProvider = new AppSettingsJsonProvider(path);
+            var comparer = StringComparer.InvariantCultureIgnoreCase;
+            var nvc = new NameValueCollection(comparer);
+            nvc.Add("Timeout", "42");
+            nvc.Add("ConnectionStrings.DefaultConnection",
+                "DataSource=app.db");
+            nvc.Add("Servers.0", "10.0.0.1");
+            nvc.Add("Servers.1", "10.0.0.2");
+            _xmlProvider = new AppSettingsXml(nvc);
         }
 
         [Test]
         public void CanReadPrimitive()
         {
-            var actual = _jsonProvider.Get("Timeout");
+            var actual = _xmlProvider.Get("Timeout");
             Assert.AreEqual("42", actual);
         }
 
@@ -26,25 +33,16 @@ namespace Tests
         [Test]
         public void CanReadNestedPrimitive()
         {
-            var actual = _jsonProvider.Get("ConnectionStrings.DefaultConnection");
+            var actual = _xmlProvider.Get("ConnectionStrings.DefaultConnection");
             Assert.AreEqual("DataSource=app.db", actual);
         }
 
         [Test]
         public void CanReadArray()
         {
-            var actual = _jsonProvider.Get("Servers.0");
+            var actual = _xmlProvider.Get("Servers.0");
             Assert.AreEqual("10.0.0.1", actual);
-            Assert.AreEqual("10.0.0.2", _jsonProvider.Get("Servers.1"));
+            Assert.AreEqual("10.0.0.2", _xmlProvider.Get("Servers.1"));
         }
-
-        [Test]
-        public void CanReadArrayOfObjects()
-        {
-            var actual = _jsonProvider.Get("Simpsons.0.Name");
-            Assert.AreEqual("Bart", actual);
-            Assert.AreEqual("Homer", _jsonProvider.Get("simpsons.1.name"));
-        }
-
     }
 }


### PR DESCRIPTION
Renamed filenames for `XmlProviderTests` and `JsonProviderTests` to correctly match the containing classes.