### PR TITLE
Refactor Provider as an Interface

### DIFF
--- a/Fig.AppSettingsXml/AppSettingsXml.cs
+++ b/Fig.AppSettingsXml/AppSettingsXml.cs
@@ -49,7 +49,7 @@ namespace Fig.AppSettingsXml
                 _caseInsensitiveMap[key] = key;
         }
 
-        public override IEnumerable<string> AllKeys(string prefix = "")
+        public IEnumerable<string> AllKeys(string prefix = "")
         {
             var comparison = StringComparison.InvariantCultureIgnoreCase;
             return _settings
@@ -57,7 +57,7 @@ namespace Fig.AppSettingsXml
                 .Where(key => key.StartsWith(prefix, comparison));
         }
 
-        public override string Get(string key)
+        public string Get(string key)
         {
             var casedKey = _caseInsensitiveMap[key];
             var result = _settings[casedKey];
@@ -65,7 +65,7 @@ namespace Fig.AppSettingsXml
             return result;
         }
 
-        public override bool TryGetValue(string key, out string value)
+        public bool TryGetValue(string key, out string value)
         {
             try
             {

--- a/Fig.Core/AppSettingsJsonProvider.cs
+++ b/Fig.Core/AppSettingsJsonProvider.cs
@@ -59,17 +59,17 @@ namespace Fig
             }
         }
 
-        public override IEnumerable<string> AllKeys(string prefix = "")
+        public IEnumerable<string> AllKeys(string prefix = "")
         {
             return _data.Keys;
         }
 
-        public override string Get(string key)
+        public string Get(string key)
         {
             return _data[key];
         }
 
-        public override bool TryGetValue(string key, out string value)
+        public bool TryGetValue(string key, out string value)
         {
             return _data.TryGetValue(key, out value);
         }

--- a/Fig.Core/DictionaryProvider.cs
+++ b/Fig.Core/DictionaryProvider.cs
@@ -15,17 +15,16 @@ namespace Fig
             = new Dictionary<string, string>(
                 StringComparer.InvariantCultureIgnoreCase);
 
-        public override IEnumerable<string> AllKeys(string prefix = "")
+        public IEnumerable<string> AllKeys(string prefix = "")
             => _data.Keys.Where(key => key.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase));
 
-        public override bool TryGetValue(string key, out string value)
+        public bool TryGetValue(string key, out string value)
             => _data.TryGetValue(key, out value);
 
-        public override string Get(string key)
+        public string Get(string key)
         {
             if (TryGetValue(key, out var result)) return result;
             throw new KeyNotFoundException(key);
         }
-
     }
 }

--- a/Fig.Core/Provider.cs
+++ b/Fig.Core/Provider.cs
@@ -3,7 +3,7 @@
 namespace Fig
 {
     /// <summary>
-    /// Base class for providers. Could probably be an interface?
+    /// Interface for all Providers
     /// </summary>
     public interface Provider
     {

--- a/Fig.Core/Provider.cs
+++ b/Fig.Core/Provider.cs
@@ -5,21 +5,21 @@ namespace Fig
     /// <summary>
     /// Base class for providers. Could probably be an interface?
     /// </summary>
-    public abstract class Provider
+    public interface Provider
     {
-        public abstract bool TryGetValue(string key, out string value);
+        bool TryGetValue(string key, out string value);
 
         /// <summary>
-        /// Return all the keys in the 
+        /// Return all the keys in the
         /// </summary>
         /// <returns></returns>
-        public abstract IEnumerable<string> AllKeys(string prefix = "");
+        IEnumerable<string> AllKeys(string prefix = "");
 
         /// <summary>
         /// Retrieve the value associated with a given key
         /// </summary>
         /// <param name="key">Case insensitive key</param>
         /// <returns>the associated value or throw a KeyNotFoundException</returns>
-        public abstract string Get(string key);
+        string Get(string key);
     }
 }


### PR DESCRIPTION
The comment was left with the question of whether the provider should be an interface or not.  In the future if the need should ever arise for it to be an abstract class, then that can be done, but at this point it is basically acting as an interface and should probably be so.  The positive side is that you can get rid of a bunch of overrides.