### PR TITLE
Issue #28: Support types IPAddress and IPEndpoint

### DIFF
--- a/Fig.Core/InvariantStringConverter.cs
+++ b/Fig.Core/InvariantStringConverter.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
+using System.Net;
 
 namespace Fig
 {
@@ -13,14 +16,17 @@ namespace Fig
 
         public object Convert(string value, Type targetType)
         {
+            if (value == null) return null;
+
             var typeConverter = TypeDescriptor.GetConverter(targetType);
 
-            if (typeConverter is ArrayConverter)
+            // Converts objects that the default TypeConverter for this type cannot convert.
+            if (ConvertSpecialObjects(typeConverter, value, targetType, out object convertedValue))
             {
-                return ConvertToArray(value, targetType);
+                return convertedValue;
             }
 
-            var convertedValue = typeConverter.ConvertFromInvariantString(value);
+            convertedValue = typeConverter.ConvertFromInvariantString(value);
 
             // If target type is an enum, check that the parsed string value is a valid value
             if (targetType.IsEnum && !Enum.IsDefined(targetType, convertedValue))
@@ -29,6 +35,29 @@ namespace Fig
             }
 
             return convertedValue;
+        }
+
+        private static bool ConvertSpecialObjects(TypeConverter converter, string value, Type targetType, out object convertedValue)
+        {
+            convertedValue = null;
+            if (converter is ArrayConverter)
+            {
+                convertedValue = ConvertToArray(value, targetType);
+                return true;
+            }
+
+            if (targetType == typeof(IPEndPoint))
+            {
+                convertedValue = ConvertIPEndPoint(value);
+                return true;
+            }
+
+            if (targetType == typeof(IPAddress))
+            {
+                convertedValue = ConvertIPAddress(value);
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -40,7 +69,6 @@ namespace Fig
         /// <returns>Array of targetType object</returns>
         private static object ConvertToArray(string value, Type targetType)
         {
-            if (value == null) return null;
             if (targetType == typeof(string[]))
             {
                 return value.Split(',');
@@ -64,13 +92,73 @@ namespace Fig
                 }
                 else
                 {
-                    values = value.Split(',').Select(a => System.Convert.ChangeType(a, elementType)).ToArray();
+                    var valuesToConvert = value.Split(',');
+                    values = new object[valuesToConvert.Length];
+                    for (int i=0; i < valuesToConvert.Length; i++)
+                    {
+                        // Attempt to convert to a special object incase the element type is one of them
+                        if (ConvertSpecialObjects(converter, valuesToConvert[i], elementType, out object convertedValue))
+                        {
+                            values[i] = convertedValue;
+                        }
+                        else
+                        {
+                            values[i] = System.Convert.ChangeType(valuesToConvert[i], elementType);
+                        }
+                    }
                 }
             }
 
             var outputArray = Array.CreateInstance(elementType, values.Length);
             Array.Copy(values, outputArray, values.Length);
             return outputArray;
+        }
+
+        /// <summary>
+        /// Basic IPAddress parser
+        /// </summary>
+        /// <param name="ipAddress"></param>
+        /// <returns></returns>
+        private static IPAddress ConvertIPAddress(string ipAddress)
+        {
+            IPAddress ip;
+            if (!IPAddress.TryParse(ipAddress, out ip))
+            {
+                throw new FormatException("Invalid ip-adress: " + ipAddress);
+            }
+            return ip;
+        }
+
+        /// <summary>
+        /// Handles both IPv4 and IPv6 notation.
+        /// </summary>
+        /// <param name="endPoint"></param>
+        /// <returns></returns>
+        private static IPEndPoint ConvertIPEndPoint(string endPoint)
+        {
+            string[] ep = endPoint.Split(':');
+            if (ep.Length < 2) throw new FormatException("Invalid endpoint format");
+            IPAddress ip;
+            if (ep.Length > 2)
+            {
+                if (!IPAddress.TryParse(string.Join(":", ep, 0, ep.Length - 1), out ip))
+                {
+                    throw new FormatException("Invalid ip-adress: " + string.Join(":", ep, 0, ep.Length - 1));
+                }
+            }
+            else
+            {
+                if (!IPAddress.TryParse(ep[0], out ip))
+                {
+                    throw new FormatException("Invalid ip-adress");
+                }
+            }
+            int port;
+            if (!int.TryParse(ep[ep.Length - 1], NumberStyles.None, NumberFormatInfo.CurrentInfo, out port))
+            {
+                throw new FormatException("Invalid port");
+            }
+            return new IPEndPoint(ip, port);
         }
     }
 }

--- a/Fig.Core/InvariantStringConverter.cs
+++ b/Fig.Core/InvariantStringConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;

--- a/Fig.Tests/StringConversionTests.cs
+++ b/Fig.Tests/StringConversionTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
+using System.Net;
 using System.Threading;
 using NUnit.Framework;
 
@@ -250,6 +252,38 @@ namespace Fig.Test
             Assert.AreEqual(new TestEnum[] { TestEnum.Option1 }, _converter.Convert<TestEnum[]>("1"));
             Assert.AreEqual(null, _converter.Convert<TestEnum[]>(null));
             Assert.That(() => _converter.Convert<TestEnum[]>("1a"), Throws.Exception);
+        }
+
+        [Test]
+        public void ConvertToIPAddress()
+        {
+            Assert.AreEqual(IPAddress.Parse("127.0.0.1"), _converter.Convert<IPAddress>("127.0.0.1"));
+            Assert.AreEqual(null, _converter.Convert<IPAddress>(null));
+        }
+
+        [Test]
+        public void ConvertToIPAddressArray()
+        {
+            Assert.AreEqual(new[] { "127.0.0.1", "18.84.21.3" }.Select(IPAddress.Parse).ToArray(), _converter.Convert<IPAddress[]>("127.0.0.1,18.84.21.3"));
+            Assert.AreEqual(new[] { IPAddress.Parse("127.0.0.1") }, _converter.Convert<IPAddress[]>("127.0.0.1"));
+            Assert.AreEqual(null, _converter.Convert<IPAddress[]>(null));
+            Assert.That(() => _converter.Convert<IPAddress[]>("localhost"), Throws.Exception);
+        }
+
+        [Test]
+        public void ConvertToIPEndPoint()
+        {
+            Assert.AreEqual(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 80), _converter.Convert<IPEndPoint>("127.0.0.1:80"));
+            Assert.AreEqual(null, _converter.Convert<IPEndPoint>(null));
+        }
+
+        [Test]
+        public void ConvertToIPEndPointArray()
+        {
+            Assert.AreEqual(new[] { "127.0.0.1", "18.84.21.3" }.Select(IPAddress.Parse).Select(a => new IPEndPoint(a, 80)).ToArray(), _converter.Convert<IPEndPoint[]>("127.0.0.1:80,18.84.21.3:80"));
+            Assert.AreEqual(new[] { new IPEndPoint(IPAddress.Parse("127.0.0.1"), 80) }, _converter.Convert<IPEndPoint[]>("127.0.0.1:80"));
+            Assert.AreEqual(null, _converter.Convert<IPEndPoint[]>(null));
+            Assert.That(() => _converter.Convert<IPEndPoint[]>("localhost:a8"), Throws.Exception);
         }
 
         private enum TestEnum

--- a/Fig.Tests/StringConversionTests.cs
+++ b/Fig.Tests/StringConversionTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Threading;
 using NUnit.Framework;
 
 namespace Fig.Test

--- a/Fig.Tests/Tests.cs
+++ b/Fig.Tests/Tests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using Fig.AppSettingsXml;
 using NUnit.Framework;
 
@@ -32,6 +33,8 @@ namespace Fig.Test
                 ["Key:PROD"] = "PROD",
                 ["Key:TEST"] = "TEST",
                 ["Key:PROD2"] = "PROD",
+                ["ServerIp"] = "127.0.0.1",
+                ["ServerEndPoint"] = "127.0.0.1:80",
 
                 ["env"] = "staging",
                 ["ExampleSettings.MyTimeSpan:staging"] = "00:15:00",
@@ -190,6 +193,25 @@ namespace Fig.Test
             Assert.AreEqual("Key", propertyChangeNotifications.Single());
         }
 
+        [Test]
+        public void CanRetrieveIPAddressFromSettings()
+        {
+            var settings = new SettingsBuilder()
+                .UseSettingsDictionary(_settingsDictionary)
+                .Build<MySettings>(prefix: "");
+
+            Assert.AreEqual(IPAddress.Parse("127.0.0.1"), settings.ServerIp);
+        }
+
+        [Test]
+        public void CanRetrieveIPEndPointFromSettings()
+        {
+            var settings = new SettingsBuilder()
+                .UseSettingsDictionary(_settingsDictionary)
+                .Build<MySettings>(prefix: "");
+
+            Assert.AreEqual(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 80), settings.ServerEndPoint);
+        }
     }
 
     class UnresolvedPropertySettings : Settings
@@ -204,6 +226,8 @@ namespace Fig.Test
         { }
 
         public TimeSpan MyTimeSpan => Get<TimeSpan>();
+        public IPAddress ServerIp => Get<IPAddress>();
+        public IPEndPoint ServerEndPoint => Get<IPEndPoint>();
 
         public string Key => Get<string>();
     }


### PR DESCRIPTION
Added support for both IPAddress and IPEndPoint (both IPv4 & IPv6 notations supported).
Tests included for both objects and their array variants.